### PR TITLE
Fix a typo and correct the directory path when auto downloading dataset

### DIFF
--- a/yolo/tools/dataset_preparation.py
+++ b/yolo/tools/dataset_preparation.py
@@ -61,7 +61,7 @@ def prepare_dataset(cfg):
             extract_to = os.path.join(data_dir, data_type) if data_type != "annotations" else data_dir
             final_place = os.path.join(extract_to, dataset_type)
 
-            os.makedirs(extract_to, exist_ok=True)
+            os.makedirs(final_place, exist_ok=True)
             if check_files(final_place, dataset_args.get("file_num")):
                 logger.info(f"✅ Dataset {dataset_type: <12} already verified.")
                 continue

--- a/yolo/tools/dataset_preparation.py
+++ b/yolo/tools/dataset_preparation.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     import sys
 
     sys.path.append("./")
-    from tools.log_helper import custom_logger
+    from utils.logging_utils import custom_logger
 
     custom_logger()
     prepare_dataset()


### PR DESCRIPTION
In dataset_preparation.py, the path that stores the downloaded dataset should be under "final_path", instead of "extract_to".
Also, import path of "custom_logger" function typo is fixed. 

- [x] The code follows the [Python style guide](https://www.python.org/dev/peps/pep-0008/).
- [x] Code and files are well organized.
- [x] All tests pass.
- [x] New code is covered by tests.
- [x] We would be very happy if [gitmoji😆](https://www.npmjs.com/package/gitmoji-cli) could be used to assist the commit message💬!
