### PR TITLE
✅ [Pass] tests, skip drawing if graphviz not found

### DIFF
--- a/yolo/model/yolo.py
+++ b/yolo/model/yolo.py
@@ -126,5 +126,5 @@ def get_model(cfg: Config) -> YOLO:
     model = YOLO(cfg.model, cfg.hyper.data.class_num)
     logger.info("✅ Success load model")
     log_model_structure(model.model)
-    # draw_model(model=model)
+    draw_model(model=model)
     return model

--- a/yolo/tools/drawer.py
+++ b/yolo/tools/drawer.py
@@ -95,6 +95,8 @@ def draw_model(*, model_cfg=None, model=None, v7_base=False):
         for jdx in range(idx, model_size):
             if model_mat[idx, jdx]:
                 dot.edge(str(idx), str(jdx))
-
-    dot.render("Model-arch", format="png", cleanup=True)
+    try:
+        dot.render("Model-arch", format="png", cleanup=True)
+    except:
+        logger.info("Warning: Could not find graphviz backend, continue without drawing the model architecture")
     logger.info("🎨 Drawing Model Architecture at Model-arch.png")


### PR DESCRIPTION
Codes to circumvent `draw_model()` when the graphviz backend can not be found added. This happens when performing pytest.

- [x] The code follows the [Python style guide](https://www.python.org/dev/peps/pep-0008/).
- [x] Code and files are well organized.
- [x] All tests pass.
- [x] New code is covered by tests.
- [x] We would be very happy if [gitmoji😆](https://www.npmjs.com/package/gitmoji-cli) could be used to assist the commit message💬!